### PR TITLE
pass godot_args to mac process

### DIFF
--- a/src/godot_manager.rs
+++ b/src/godot_manager.rs
@@ -505,10 +505,14 @@ impl<'a> GodotManager<'a> {
                 }
                 if console {
                     // On macOS, running attached is the default behavior
-                    std::process::Command::new(inner_path).spawn()?;
+                    std::process::Command::new(inner_path)
+                        .args(godot_args)
+                        .spawn()?;
                 } else {
                     // Detached process
-                    std::process::Command::new(inner_path).spawn()?;
+                    std::process::Command::new(inner_path)
+                        .args(godot_args)
+                        .spawn()?;
                 }
                 return Ok(());
             }


### PR DESCRIPTION
Passes the godot_args when invoking gdvm run